### PR TITLE
27 refactor test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@ Note that it relies on having a LIVE_ENV variable set that will indicate which c
 
 To do rudimentary debugging, put debugger in the code where you wish to stop and debug, and run
 
+```
 npm run-script debug
+```
 
 Unfortunately, you will probably need to type c for continue because it will get stuck on the first require.
 
 After continuing and hitting upon the first debugger instance of interest, type repl and you will be put into a state where you can inspect the variables like so:
 
+```
 repl
 Press Ctrl + C to leave debug repl
 > req
@@ -22,7 +25,7 @@ Press Ctrl + C to leave debug repl
      type: 'Scrum',
      project: 'localsupport' },
   post: [Function] }
-
+```
 
 Below is the original Hubot README
 ----------------------------------

--- a/README.md
+++ b/README.md
@@ -5,6 +5,23 @@ Agile Bot takes requests to notify Slack and Gitter about pairing hangouts and y
 
 Note that it relies on having a LIVE_ENV variable set that will indicate which channels to hit - that LIVE_ENV var should be set to 'production' or 'staging'.
 
+To do rudimentary debugging, put debugger in the code where you wish to stop and debug, and run
+
+npm run-script debug
+
+Unfortunately, you will probably need to type c for continue because it will get stuck on the first require.
+
+After continuing and hitting upon the first debugger instance of interest, type repl and you will be put into a state where you can inspect the variables like so:
+
+repl
+Press Ctrl + C to leave debug repl
+> req
+{ body: 
+   { host_name: 'jon',
+     host_avatar: 'jon.jpg',
+     type: 'Scrum',
+     project: 'localsupport' },
+  post: [Function] }
 
 
 Below is the original Hubot README

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "sepia": "^2.0.1"
   },
   "scripts": {
-    "test": "./node_modules/.bin/jasmine ENABLE_ROLLBAR=false GITTER_API_TOKEN=101010"
+    "test": "./node_modules/.bin/jasmine ENABLE_ROLLBAR=false GITTER_API_TOKEN=101010",
+    "debug": "ENABLE_ROLLBAR=false GITTER_API_TOKEN=101010 node debug node_modules/.bin/jasmine"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "sepia": "^2.0.1"
   },
   "scripts": {
-    "test": "./node_modules/.bin/jasmine ENABLE_ROLLBAR=false GITTER_API_TOKEN=101010",
+    "test": "./node_modules/.bin/jasmine --random=true ENABLE_ROLLBAR=false GITTER_API_TOKEN=101010",
     "debug": "ENABLE_ROLLBAR=false GITTER_API_TOKEN=101010 node debug node_modules/.bin/jasmine"
   }
 }

--- a/scripts/av-hangouts-notifications.coffee
+++ b/scripts/av-hangouts-notifications.coffee
@@ -108,7 +108,7 @@ module.exports = (robot) ->
 # host_name = Random Guy
 # host_avatar = https://www.gravatar.com/avatar/fsd87fgds87f4387
     user = name: req.body.host_name, avatar: req.body.host_avatar
-
+    debugger
     if req.body.type == "Scrum"
       send_slack_message CHANNELS.general, "Video/Livestream for #{req.body.title}: #{req.body.video}", user
     else if req.body.type == "PairProgramming"

--- a/scripts/av-hangouts-notifications.coffee
+++ b/scripts/av-hangouts-notifications.coffee
@@ -108,7 +108,6 @@ module.exports = (robot) ->
 # host_name = Random Guy
 # host_avatar = https://www.gravatar.com/avatar/fsd87fgds87f4387
     user = name: req.body.host_name, avatar: req.body.host_avatar
-    debugger
     if req.body.type == "Scrum"
       send_slack_message CHANNELS.general, "Video/Livestream for #{req.body.title}: #{req.body.video}", user
     else if req.body.type == "PairProgramming"

--- a/spec/avHangoutsNotificationsSpec.coffee
+++ b/spec/avHangoutsNotificationsSpec.coffee
@@ -10,7 +10,7 @@ makeRequest = (routes_functions, type, project, done) ->
   routes_functions['/hubot/hangouts-notify'](req, res)
   setTimeout (->
     done()
-  ), 1
+  ), 2
 
 mockSlackHangoutNotify = (routes_functions, channel, type, project) ->
   text = if type == "Scrum" || channel == 'C02A6835V' then '@here undefined: undefined' else 'undefined: undefined'
@@ -20,7 +20,7 @@ mockSlackHangoutNotify = (routes_functions, channel, type, project) ->
   nock("https://api.gitter.im")
     .post("/v1/rooms/56b8bdffe610378809c070cc/chatMessages")
     .reply(200, {error: 'not_authed'})
-  nock('https://slack.com', allowUnmocked: true)
+  nock('https://slack.com', allowUnmocked: false)
     .post('/api/chat.postMessage',
       channel: channel,
       text: text,

--- a/spec/avHangoutsNotificationsSpec.coffee
+++ b/spec/avHangoutsNotificationsSpec.coffee
@@ -1,31 +1,30 @@
 nock = require('nock');
 avHangoutsNotifications = require('../scripts/av-hangouts-notifications.coffee')
-debugger
 
-# endpoint, channel, text, username, icon_url, parse,
-mockHangoutVideoNotify = (routes_functions, channel, type, project, done) ->
-  slack = nock('https://slack.com', allowUnmocked: false)
-    .post('/api/chat.postMessage',
-      channel: channel,
-      text: 'Video/Livestream for undefined: undefined',
-      username: 'jon',
-      icon_url: 'jon.jpg',
-      parse: 'full'
-    )
-    .reply(200, {
-      ok: false,
-      error: 'not_authed'
-    });
-  res = {}
-  res.writeHead = -> {}
-  res.end = -> {}
-  req = {body: {host_name: 'jon', host_avatar: 'jon.jpg', type: type, project: project}}
-  req.post = -> {}
-  routes_functions['/hubot/hangouts-video-notify'](req, res)
-  setTimeout (->
-    done()
-  ), 1
-  slack
+#endpoint, channel, text, username, icon_url, parse,
+# mockHangoutVideoNotify = (routes_functions, channel, type, project, done) ->
+#   slack = nock('https://slack.com', allowUnmocked: false)
+#     .post('/api/chat.postMessage',
+#       channel: channel,
+#       text: 'Video/Livestream for undefined: undefined',
+#       username: 'jon',
+#       icon_url: 'jon.jpg',
+#       parse: 'full'
+#     )
+#     .reply(200, {
+#       ok: false,
+#       error: 'not_authed'
+#     });
+#   res = {}
+#   res.writeHead = -> {}
+#   res.end = -> {}
+#   req = {body: {host_name: 'jon', host_avatar: 'jon.jpg', type: type, project: project}}
+#   req.post = -> {}
+#   #routes_functions['/hubot/hangouts-video-notify'](req, res)
+#   setTimeout (->
+#     done()
+#   ), 1
+#   slack
 
 makeRequest = (routes_functions, type, project, done) ->
   res = {}
@@ -66,31 +65,14 @@ describe 'AV Hangout Notifications', ->
 
   it 'has appropriate routes', ->
     expect(typeof @routes_functions['/hubot/hangouts-notify']).toBe("function")
-    expect(typeof @routes_functions['/hubot/hangouts-video-notify']).toBe("function")
 
-  describe 'hangouts-video-notify for scrum', ->
-    beforeEach (done) ->
-      @slack = mockHangoutVideoNotify(@routes_functions, 'C0TLAE1MH', 'Scrum', 'localsupport', done)
+  # describe 'hangouts-video-notify for pairing on cs169', ->
+  #   beforeEach (done) ->
+  #     @slack = mockHangoutVideoNotify(@routes_functions, 'C02A6835V', 'PairProgramming', 'cs169', done)
 
-    it 'should post scrum video link to general channel', (done) ->
-      expect(@slack.isDone()).toBe(true, 'expected HTTP endpoint was not hit')
-      done()
-
-  describe 'hangouts-video-notify for pairing', ->
-    beforeEach (done) ->
-      @slack = mockHangoutVideoNotify(@routes_functions, 'C0TLAE1MH', 'PairProgramming', 'localsupport', done)
-
-    it 'should post pair hangout link to general channel', (done) ->
-      expect(@slack.isDone()).toBe(true, 'expected HTTP endpoint was not hit')
-      done()
-
-  describe 'hangouts-video-notify for pairing on cs169', ->
-    beforeEach (done) ->
-      @slack = mockHangoutVideoNotify(@routes_functions, 'C02A6835V', 'PairProgramming', 'cs169', done)
-
-    it 'should not post pair hangout link to mooc channel on slack', (done) ->
-      expect(@slack.isDone()).toBe(false, 'unexpected HTTP endpoint was hit')
-      done()
+  #   it 'should not post pair hangout link to mooc channel on slack', (done) ->
+  #     expect(@slack.isDone()).toBe(false, 'unexpected HTTP endpoint was hit')
+  #     done()
 
   describe 'hangouts-notify for scrum', ->
     beforeEach (done) ->

--- a/spec/avHangoutsNotificationsSpec.coffee
+++ b/spec/avHangoutsNotificationsSpec.coffee
@@ -1,31 +1,6 @@
 nock = require('nock');
 avHangoutsNotifications = require('../scripts/av-hangouts-notifications.coffee')
 
-#endpoint, channel, text, username, icon_url, parse,
-# mockHangoutVideoNotify = (routes_functions, channel, type, project, done) ->
-#   slack = nock('https://slack.com', allowUnmocked: false)
-#     .post('/api/chat.postMessage',
-#       channel: channel,
-#       text: 'Video/Livestream for undefined: undefined',
-#       username: 'jon',
-#       icon_url: 'jon.jpg',
-#       parse: 'full'
-#     )
-#     .reply(200, {
-#       ok: false,
-#       error: 'not_authed'
-#     });
-#   res = {}
-#   res.writeHead = -> {}
-#   res.end = -> {}
-#   req = {body: {host_name: 'jon', host_avatar: 'jon.jpg', type: type, project: project}}
-#   req.post = -> {}
-#   #routes_functions['/hubot/hangouts-video-notify'](req, res)
-#   setTimeout (->
-#     done()
-#   ), 1
-#   slack
-
 makeRequest = (routes_functions, type, project, done) ->
   res = {}
   res.writeHead = -> {}
@@ -65,14 +40,6 @@ describe 'AV Hangout Notifications', ->
 
   it 'has appropriate routes', ->
     expect(typeof @routes_functions['/hubot/hangouts-notify']).toBe("function")
-
-  # describe 'hangouts-video-notify for pairing on cs169', ->
-  #   beforeEach (done) ->
-  #     @slack = mockHangoutVideoNotify(@routes_functions, 'C02A6835V', 'PairProgramming', 'cs169', done)
-
-  #   it 'should not post pair hangout link to mooc channel on slack', (done) ->
-  #     expect(@slack.isDone()).toBe(false, 'unexpected HTTP endpoint was hit')
-  #     done()
 
   describe 'hangouts-notify for scrum', ->
     beforeEach (done) ->

--- a/spec/avHangoutsVideoNotificationsSpec.coffee
+++ b/spec/avHangoutsVideoNotificationsSpec.coffee
@@ -10,7 +10,7 @@ makeRequest = (routes_functions, type, project, done) ->
   routes_functions['/hubot/hangouts-video-notify'](req, res)
   setTimeout (->
     done()
-  ), 1
+  ), 2
 
 # endpoint, channel, text, username, icon_url, parse,
 mockHangoutVideoNotify = (routes_functions, channel, type, project, done) ->

--- a/spec/avHangoutsVideoNotificationsSpec.coffee
+++ b/spec/avHangoutsVideoNotificationsSpec.coffee
@@ -1,0 +1,66 @@
+nock = require('nock');
+avHangoutsNotifications = require('../scripts/av-hangouts-notifications.coffee')
+
+makeRequest = (routes_functions, type, project, done) ->
+  res = {}
+  res.writeHead = -> {}
+  res.end = -> {}
+  req = {body: {host_name: 'jon', host_avatar: 'jon.jpg', type: type, project: project}}
+  req.post = -> {}
+  routes_functions['/hubot/hangouts-video-notify'](req, res)
+  setTimeout (->
+    done()
+  ), 1
+
+# endpoint, channel, text, username, icon_url, parse,
+mockHangoutVideoNotify = (routes_functions, channel, type, project, done) ->
+  nock('https://slack.com', allowUnmocked: false)
+    .post('/api/chat.postMessage',
+      channel: channel,
+      text: 'Video/Livestream for undefined: undefined',
+      username: 'jon',
+      icon_url: 'jon.jpg',
+      parse: 'full'
+    )
+    .reply(200, {
+      ok: false,
+      error: 'not_authed'
+    });
+
+describe 'AV Video Hangout Notifications', ->
+  beforeEach ->
+    routes_functions = {}
+    avHangoutsNotifications({router: {post: (s, f) -> routes_functions[s] = f}})
+    @routes_functions = routes_functions
+
+  it 'has appropriate routes', ->
+    expect(typeof @routes_functions['/hubot/hangouts-video-notify']).toBe("function")
+
+  describe 'hangouts-video-notify for scrum', ->
+    beforeEach (done) ->
+      @slack = mockHangoutVideoNotify(@routes_functions, 'C0TLAE1MH', 'Scrum', 'localsupport', done)
+      makeRequest(@routes_functions, 'Scrum', 'localsupport', done)
+
+    it 'should post scrum video link to general channel', (done) ->
+      expect(@slack.isDone()).toBe(true, 'expected HTTP endpoint was not hit')
+      done()
+
+  describe 'hangouts-video-notify for pairing', ->
+    beforeEach (done) ->
+      @slack = mockHangoutVideoNotify(@routes_functions, 'C0TLAE1MH', 'PairProgramming', 'localsupport', done)
+      mockHangoutVideoNotify(@routes_functions, 'C0KK907B5', 'PairProgramming', 'localsupport', done)
+      makeRequest(@routes_functions, 'PairProgramming', 'localsupport', done)
+
+    it 'should post pair hangout link to general channel', (done) ->
+      expect(@slack.isDone()).toBe(true, 'expected HTTP endpoint was not hit')
+      done()
+
+  describe 'hangouts-video-notify for pairing on cs169', ->
+    beforeEach (done) ->
+      @slack = mockHangoutVideoNotify(@routes_functions, 'C02A6835V', 'PairProgramming', 'cs169', done)
+      makeRequest(@routes_functions, 'PairProgramming', 'cs169', done)
+    
+    it 'should not post pair hangout link to mooc channel on slack', (done) ->
+      expect(@slack.isDone()).toBe(false, 'unexpected HTTP endpoint was hit')
+      done()
+

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -7,5 +7,5 @@
     "helpers/**/*.js"
   ],
   "stopSpecOnExpectationFailure": false,
-  "random": false
+  "random": true
 }


### PR DESCRIPTION
This breaks up the tests into two files. Makes changes to make this stable. Pull off this branch and confirm it is working reliably for your locally.

Fixes #28
